### PR TITLE
INT-1197: Ensure invalid domain lookups don't throw an error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "AlienvaultOTX-PassiveDNS",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AlienvaultOTX-PassiveDNS",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "main": "./integration.js",
   "private": true,
   "dependencies": {

--- a/src/assembleLookupResults.js
+++ b/src/assembleLookupResults.js
@@ -8,6 +8,13 @@ const assembleLookupResults = (passiveDNS, options) =>
     const Logger = getLogger();
     const maxResults = get('maxResults', options);
 
+    if (!result) {
+      return {
+        entity,
+        data: null
+      };
+    }
+
     if (result.count === 0) {
       return {
         entity,

--- a/src/assembleLookupResults.js
+++ b/src/assembleLookupResults.js
@@ -1,21 +1,11 @@
 const { map, get, minBy } = require('lodash/fp');
-const {
-  logging: { getLogger }
-} = require('polarity-integration-utils');
+
 const assembleLookupResults = (passiveDNS, options) =>
   map(({ entity, result }) => {
     // Remove extra results if maxResults is set
-    const Logger = getLogger();
     const maxResults = get('maxResults', options);
 
-    if (!result) {
-      return {
-        entity,
-        data: null
-      };
-    }
-
-    if (result.count === 0) {
+    if (!result || result.count === 0) {
       return {
         entity,
         data: null

--- a/src/queries/getPassiveDNS.js
+++ b/src/queries/getPassiveDNS.js
@@ -5,13 +5,15 @@ const ALIENVAULT_OTX_DOMAIN_BASE_URL =
   'https://otx.alienvault.com/otxapi/indicators/domain/passive_dns/';
 
 const ALIENVAULT_OTX_IP_BASE_URL =
-    'https://otx.alienvault.com/otxapi/indicators/IPv4/passive_dns/';
+  'https://otx.alienvault.com/otxapi/indicators/IPv4/passive_dns/';
 
 const getPassiveDNS = async (entities, options) => {
   const dnsRequests = map(
     (entity) => ({
       entity,
-      url: entity.isDomain ? ALIENVAULT_OTX_DOMAIN_BASE_URL + entity.value : ALIENVAULT_OTX_IP_BASE_URL + entity.value,
+      url: entity.isDomain
+        ? ALIENVAULT_OTX_DOMAIN_BASE_URL + entity.value
+        : ALIENVAULT_OTX_IP_BASE_URL + entity.value,
       method: 'GET',
       options
     }),
@@ -20,12 +22,7 @@ const getPassiveDNS = async (entities, options) => {
 
   const dnsResponses = await requestsInParallel(dnsRequests, 'body');
 
-  const dnsResponsesWithResultsObject = map((response) => ({
-    ...response,
-    result: JSON.parse(response.result)
-  }))(dnsResponses);
-
-  return dnsResponsesWithResultsObject;
+  return dnsResponses;
 };
 
 module.exports = getPassiveDNS;

--- a/src/request/authenticateRequest.js
+++ b/src/request/authenticateRequest.js
@@ -5,7 +5,8 @@ const authenticateRequest = async (requestOptions) => ({
   headers: {
     ...get('headers', requestOptions),
     Authorization: `${requestOptions.options.apiKey}`
-  }
+  },
+  json: true
 });
 
 module.exports = authenticateRequest;

--- a/src/request/index.js
+++ b/src/request/index.js
@@ -16,7 +16,7 @@ const requestWithDefaults = createRequestWithDefaults({
     if (error.status === 400 && error.description.includes('Invalid domain')) {
       return;
     }
-    throw Error;
+    throw error;
   }
 });
 

--- a/src/request/index.js
+++ b/src/request/index.js
@@ -1,9 +1,6 @@
 const authenticateRequest = require('./authenticateRequest');
 const config = require('../../config/config');
 const {
-  logging: { getLogger }
-} = require('polarity-integration-utils');
-const {
   requests: { createRequestWithDefaults }
 } = require('polarity-integration-utils');
 


### PR DESCRIPTION
The domain parser on web search will sometimes send invalid domains to AlienVault to be looked up (invalid TLD).  When that happens Alienvault will return a 400 and an error message that includes the text "Invalid Domain".  This PR catches that specific error and ignores it by capturing that result as a miss.